### PR TITLE
Add Flutter/Dart CI workflow

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,0 +1,68 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'flutter_module/**'
+      - 'flutter_sharp/**'
+      - '.github/workflows/flutter-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'flutter_module/**'
+      - 'flutter_sharp/**'
+      - '.github/workflows/flutter-ci.yml'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Get dependencies
+        working-directory: flutter_module
+        run: flutter pub get
+
+      - name: Analyze
+        working-directory: flutter_module
+        run: flutter analyze
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Get dependencies
+        working-directory: flutter_module
+        run: flutter pub get
+
+      - name: Run tests
+        working-directory: flutter_module
+        run: flutter test
+
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed flutter_module/lib/


### PR DESCRIPTION
Adds `.github/workflows/flutter-ci.yml` to run CI on the Dart/Flutter side of the codebase.

## Jobs

| Job | Command | Working dir |
|-----|---------|-------------|
| **analyze** | `flutter analyze` | `flutter_module/` |
| **test** | `flutter test` | `flutter_module/` |
| **format-check** | `dart format --output=none --set-exit-if-changed` | `flutter_module/lib/` |

## Triggers

- Push/PR to `main` when files under `flutter_module/`, `flutter_sharp/`, or this workflow change

## Notes

- Uses `subosito/flutter-action@v2` on the `stable` channel with pub cache enabled
- Handles the local path dependency (`flutter_sharp/`) automatically via full repo checkout
- Test job runs against existing `flutter_module/test/widget_test.dart`